### PR TITLE
Change DaemonSet apiVersion for bridge2transparent

### DIFF
--- a/03-TigeraSecure-Install/bridge-to-transparent.yaml
+++ b/03-TigeraSecure-Install/bridge-to-transparent.yaml
@@ -121,11 +121,14 @@ spec:
 
 ---
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: bridge2transparent
 spec:
+  selector:
+    matchLabels:
+      run-once-daemonset: bridge2transparent
   template:
     metadata:
       labels:


### PR DESCRIPTION
Move apiVersion from extensions/v1beta1 to apps/v1.

Add the .spec.selector field.
It must specify a pod selector that matches the labels of the .spec.template.