### PR TITLE
fix incompatibility of bridge-to-transparent with k8s v1.16+

### DIFF
--- a/03-TigeraSecure-Install/bridge-to-transparent.yaml
+++ b/03-TigeraSecure-Install/bridge-to-transparent.yaml
@@ -43,10 +43,10 @@ metadata:
   name: kured
 rules:
 # Allow kured to lock/unlock itself
-- apiGroups:     ["extensions"]
+- apiGroups:     ["extensions","apps"]
   resources:     ["daemonsets"]
   resourceNames: ["kured"]
-  verbs:         ["update"]
+  verbs:         ["get","update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/03-TigeraSecure-Install/bridge-to-transparent.yaml
+++ b/03-TigeraSecure-Install/bridge-to-transparent.yaml
@@ -8,7 +8,7 @@ rules:
 # Allow kubectl to drain/uncordon
 #
 # NB: These permissions are tightly coupled to the bundled version of kubectl; the ones below
-# match https://github.com/kubernetes/kubernetes/blob/v1.12.1/pkg/kubectl/cmd/drain.go
+# match https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/drain/drain.go
 #
 - apiGroups: [""]
   resources: ["nodes"]
@@ -16,9 +16,9 @@ rules:
 - apiGroups: [""]
   resources: ["pods"]
   verbs:     ["list","delete","get"]
-- apiGroups: ["extensions"]
+- apiGroups: ["extensions","apps"]
   resources: ["daemonsets"]
-  verbs:     ["get"]
+  verbs:     ["get","update"]
 - apiGroups: [""]
   resources: ["pods/eviction"]
   verbs:     ["create"]

--- a/03-TigeraSecure-Install/bridge-to-transparent.yaml
+++ b/03-TigeraSecure-Install/bridge-to-transparent.yaml
@@ -8,7 +8,7 @@ rules:
 # Allow kubectl to drain/uncordon
 #
 # NB: These permissions are tightly coupled to the bundled version of kubectl; the ones below
-# match https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/drain/drain.go
+# match https://github.com/kubernetes/kubernetes/blob/v1.12.1/pkg/kubectl/cmd/drain.go
 #
 - apiGroups: [""]
   resources: ["nodes"]
@@ -92,7 +92,7 @@ spec:
       restartPolicy: Always
       containers:
         - name: kured
-          image: docker.io/weaveworks/kured:1.2.0
+          image: docker.io/weaveworks/kured:1.4.0
           imagePullPolicy: IfNotPresent
           securityContext:
             privileged: true # Give permission to nsenter /proc/1/ns/mnt


### PR DESCRIPTION
* add `apps` apiGroup to `kured` ClusterRole for `daemonsets` resource
* add `update` verb to `kured` ClusterRole for `daemonsets` resource